### PR TITLE
Add optional `lastModified` header

### DIFF
--- a/src/ios/CocoaHttpd/HTTPConnection.m
+++ b/src/ios/CocoaHttpd/HTTPConnection.m
@@ -1199,9 +1199,15 @@ static NSMutableArray *recentNonces;
 			response = [self newMultiRangeResponse:contentLength];
 		}
 	}
-	
+
+	// Add optional lastModified header
+	if ([httpResponse respondsToSelector:@selector(lastModified)])
+	{
+		[response setHeaderField:@"Last-Modified" value:[self dateAsString:[httpResponse lastModified]]];
+	}
+
 	BOOL isZeroLengthResponse = !isChunked && (contentLength == 0);
-    
+
 	// If they issue a 'HEAD' command, we don't have to include the file
 	// If they issue a 'GET' command, we need to include the file
 	

--- a/src/ios/CocoaHttpd/HTTPResponse.h
+++ b/src/ios/CocoaHttpd/HTTPResponse.h
@@ -62,6 +62,11 @@
 - (NSInteger)status;
 
 /**
+ * LastModified date of the data.
+ **/
+- (NSDate *)lastModified;
+
+/**
  * If you want to add any extra HTTP headers to the response,
  * simply return them in a dictionary in this method.
 **/

--- a/src/ios/CocoaHttpd/Responses/HTTPFileResponse.h
+++ b/src/ios/CocoaHttpd/Responses/HTTPFileResponse.h
@@ -11,6 +11,7 @@
 	NSString *filePath;
 	UInt64 fileLength;
 	UInt64 fileOffset;
+	NSDate *fileLastModified;
 	
 	BOOL aborted;
 	

--- a/src/ios/CocoaHttpd/Responses/HTTPFileResponse.m
+++ b/src/ios/CocoaHttpd/Responses/HTTPFileResponse.m
@@ -44,6 +44,7 @@ static const int httpLogLevel = HTTP_LOG_LEVEL_WARN; // | HTTP_LOG_FLAG_TRACE;
 		}
 		
 		fileLength = (UInt64)[[fileAttributes objectForKey:NSFileSize] unsignedLongLongValue];
+		fileLastModified = (NSDate *)[fileAttributes objectForKey:NSFileModificationDate];
 		fileOffset = 0;
 		
 		aborted = NO;
@@ -104,6 +105,13 @@ static const int httpLogLevel = HTTP_LOG_LEVEL_WARN; // | HTTP_LOG_FLAG_TRACE;
 	HTTPLogTrace();
 	
 	return fileLength;
+}
+
+- (NSDate *)lastModified
+{
+	HTTPLogTrace();
+
+	return fileLastModified;
 }
 
 - (UInt64)offset


### PR DESCRIPTION
With this PR I propose adding an option `lastModified` header to file responses. This would allow for client side caching which improves rendering. The PR only addresses the iOS platform for now.