### PR TITLE
fixed server crashing issues when request is empty

### DIFF
--- a/src/android/NanoHTTPD.java
+++ b/src/android/NanoHTTPD.java
@@ -503,7 +503,7 @@ public class NanoHTTPD
 			try {
 				// Read the request line
 				String inLine = in.readLine();
-				if (inLine == null) return;
+				if (inLine == null) sendError( HTTP_BADREQUEST, "BAD REQUEST: Syntax error. Usage: GET /example/file.html" );
 				StringTokenizer st = new StringTokenizer( inLine );
 				if ( !st.hasMoreTokens())
 					sendError( HTTP_BADREQUEST, "BAD REQUEST: Syntax error. Usage: GET /example/file.html" );


### PR DESCRIPTION
After implementing cordova-httpd, i found my app crashing frequently. After researching into it, found this solution made by @kbalasub that ends up fixing the problem with random empty requests.

> Method can be missing when a socket connection is made without any input stream bytes. In other words when is.read returns a -1. I noticed this in testing with the VideoView and streaming in conjunction with NanoHTTPD. Sometimes the HTTPSession is started based on socket accept without any input stream bytes! In this case the method field is never populated inside decode header due to the below lines.
> 
> String inLine = in.readLine();
> if (inLine == null) return;
> 
> I thought of adding the check at reading the input stream itself (by checking whether the bytes read were -1) but I thought this method check was a safer option. I will change it to check for an empty request.