### PR TITLE
Add support for external SVG files on both IOS and Android

### DIFF
--- a/src/android/NanoHTTPD.java
+++ b/src/android/NanoHTTPD.java
@@ -1104,30 +1104,35 @@ public class NanoHTTPD
 	static
 	{
 		StringTokenizer st = new StringTokenizer(
-				"css		text/css "+
-						"htm		text/html "+
-						"html		text/html "+
-						"xml		text/xml "+
-						"txt		text/plain "+
-						"asc		text/plain "+
-						"gif		image/gif "+
-						"jpg		image/jpeg "+
-						"jpeg		image/jpeg "+
-						"png		image/png "+
-						"mp3		audio/mpeg "+
-						"m3u		audio/mpeg-url " +
-						"mp4		video/mp4 " +
-						"ogv		video/ogg " +
-						"flv		video/x-flv " +
-						"mov		video/quicktime " +
-						"swf		application/x-shockwave-flash " +
-						"js			application/javascript "+
-						"pdf		application/pdf "+
-						"doc		application/msword "+
-						"ogg		application/x-ogg "+
-						"zip		application/octet-stream "+
-						"exe		application/octet-stream "+
-				"class		application/octet-stream " );
+			"css		text/css "+
+			"htm		text/html "+
+			"html		text/html "+
+			"xml		text/xml "+
+			"java		java=text/x-java-source "+
+			"md			text/plain "+
+			"txt		text/plain "+
+			"asc		text/plain "+
+			"gif		image/gif "+
+			"jpg		image/jpeg "+
+			"jpeg		image/jpeg "+
+			"png		image/png "+
+			"svg		image/svg+xml "+
+			"mp3		audio/mpeg "+
+			"m3u		audio/mpeg-url " +
+			"mp4		video/mp4 " +
+			"ogv		video/ogg " +
+			"flv		video/x-flv " +
+			"mov		video/quicktime " +
+			"swf		application/x-shockwave-flash " +
+			"js			application/javascript "+
+			"pdf		application/pdf "+
+			"doc		application/msword "+
+			"ogg		application/x-ogg "+
+			"zip		application/octet-stream "+
+			"exe		application/octet-stream "+
+			"class		application/octet-stream "+
+			"m3u8		application/vnd.apple.mpegurl "+ 
+			"ts			video/mp2t " );
 		while ( st.hasMoreTokens())
 			theMimeTypes.put( st.nextToken(), st.nextToken());
 	}

--- a/src/android/NanoHTTPD.java
+++ b/src/android/NanoHTTPD.java
@@ -1093,6 +1093,10 @@ public class NanoHTTPD
 		}
 
 		res.addHeader( "Accept-Ranges", "bytes"); // Announce that the file server accepts partial content requestes
+
+		// Add CORS header
+		res.addHeader( "Access-Control-Allow-Origin", "*");
+
 		return res;
 	}
 

--- a/src/ios/CocoaHttpd/HTTPConnection.m
+++ b/src/ios/CocoaHttpd/HTTPConnection.m
@@ -1200,6 +1200,9 @@ static NSMutableArray *recentNonces;
 		}
 	}
 
+	// Add CORS header
+	[response setHeaderField:@"Access-Control-Allow-Origin" value:@"*"];
+
 	// Add optional lastModified header
 	if ([httpResponse respondsToSelector:@selector(lastModified)])
 	{

--- a/src/ios/CocoaHttpd/Responses/HTTPFileResponse.m
+++ b/src/ios/CocoaHttpd/Responses/HTTPFileResponse.m
@@ -242,4 +242,13 @@ static const int httpLogLevel = HTTP_LOG_LEVEL_WARN; // | HTTP_LOG_FLAG_TRACE;
 	
 }
 
+
+- (NSDictionary *)httpHeaders {
+  //HTTPLogTrace();
+  if ([[filePath pathExtension] isEqualToString:@"svg"]) {
+    return [NSDictionary dictionaryWithObject:@"image/svg+xml" forKey:@"Content-Type"];
+  }
+  return [NSDictionary new];
+}
+
 @end


### PR DESCRIPTION
Current implemntation of httpd on both IOS (CocoaHttpd) and Android (NanoHTTPD) lack support for loading external SVG files. If SVG is included inline - everything works, but external ones do not show at all.

I have:

- updated default-mimetypes from NanoHttpd/nanohttpd for Android (https://github.com/NanoHttpd/nanohttpd/blob/fd80618e93d17f8f05e11006eaa048a22213714d/core/src/main/resources/META-INF/nanohttpd/default-mimetypes.properties)

- included IOS fix by @hungryShadow from issue #54 

The results are captured below.

Best
Neven

# IOS 

## before

![ios not ok](https://www.nivas.hr/pub/cordova-httpd/ios-not-ok.JPG)

## after

![ios ok](https://www.nivas.hr/pub/cordova-httpd/ios-ok.JPG)

# android

## before
![android not ok](https://www.nivas.hr/pub/cordova-httpd/android-not-ok.png)

## after 

![android ok](https://www.nivas.hr/pub/cordova-httpd/android-ok.png)