### PR TITLE
@ionic-native/httpd plugin wrapper compatibility for use with Capacitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .settings
 .idea
 *.iml
+*~

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## CorHttpd: embeded httpd for cordova ##
+## CorHttpd: embeded httpd for cordova & capacitor ##
 
 Supported platform:
 * iOS
@@ -9,6 +9,7 @@ You can browse (locally or remotely) to access files in android/ios phone/pad:
 * browse the files in mobile device with a browser in PC.
 * copy files from mobile device to PC quickly, just with Wifi.
 * use cordova webview to access the assets/www/ content with http protocol.
+  * if using capacitor, set `www_dir_name` to `public`. 
 
 Why http access is good?
 
@@ -18,6 +19,8 @@ Why http access is good?
 
 ## How to use CorHttpd? ##
 
+**Cordova**
+
 Add the plugin to your cordova project:
 
     cordova plugin add https://github.com/floatinghotpot/cordova-httpd.git
@@ -25,6 +28,10 @@ Add the plugin to your cordova project:
 Quick start, copy the demo files, and just build to play.
 
     cp -r plugins/com.rjfun.cordova.httpd/test/* www/
+
+**Capacitor**
+
+Follow these [instructions](https://ionicframework.com/docs/native/httpd/).
     
 ## Javascript APIs ##
 
@@ -75,13 +82,15 @@ Example code: (read the comments)
     	    	if(url.length > 0) {
     	    		document.getElementById('url').innerHTML = "server is up: <a href='" + url + "' target='_blank'>" + url + "</a>";
 	    	    } else {
-	    	        /* wwwroot is the root dir of web server, it can be absolute or relative path
-	    	        * if a relative path is given, it will be relative to cordova assets/www/ in APK.
-	    	        * "", by default, it will point to cordova assets/www/, it's good to use 'htdocs' for 'www/htdocs'
-	    	        * if a absolute path is given, it will access file system.
-	    	        * "/", set the root dir as the www root, it maybe a security issue, but very powerful to browse all dir
+	    	       /* For capacitor users, set www_dir_name to "public". For Cordova users the default is "www". 
+                    * wwwroot is the root dir of web server and child dir of www_dir_name, it can be an absolute or relative path
+	    	        * if a relative path is given, it will be relative to assets/www/ for cordova users or public for capacitor users, depending on the value of www_dir_name.
+	    	        * if it is "", by default, it will point to cordova assets/www/ or capacitor public, depending on the value of www_dir_name. For cordova, it's good to use 'htdocs' for 'www/htdocs'
+	    	        * if an absolute path is given, it will access the file system, even if www_dir_name is set.
+	    	        * "/", set the root dir as the www root even if www_dir_name is set, it maybe a security issue, but very powerful to browse all dir
 	    	        */
     	    	    httpd.startServer({
+                        'www_dir_name': "www",
     	    	    	'www_root' : wwwroot,
     	    	    	'port' : 8080,
     	    	    	'localhost_only' : false

--- a/src/ios/CorHttpd.m
+++ b/src/ios/CorHttpd.m
@@ -12,13 +12,13 @@
 
 @interface CorHttpd : CDVPlugin {
     // Member variables go here.
-
 }
 
 @property(nonatomic, retain) HTTPServer *httpServer;
 @property(nonatomic, retain) NSString *localPath;
 @property(nonatomic, retain) NSString *url;
 
+@property (nonatomic, retain) NSString* www_dir_name;
 @property (nonatomic, retain) NSString* www_root;
 @property (assign) int port;
 @property (assign) BOOL localhost_only;
@@ -40,6 +40,7 @@
 #define IP_ADDR_IPv4    @"ipv4"
 #define IP_ADDR_IPv6    @"ipv6"
 
+#define OPT_WWW_DIR_NAME    @"www_dir_name"
 #define OPT_WWW_ROOT        @"www_root"
 #define OPT_PORT            @"port"
 #define OPT_LOCALHOST_ONLY  @"localhost_only"
@@ -111,6 +112,7 @@
     self.localPath = @"";
     self.url = @"";
 
+    self.www_dir_name = @"www";
     self.www_root = @"";
     self.port = 8888;
     self.localhost_only = false;
@@ -122,7 +124,10 @@
 
     NSDictionary* options = [command.arguments objectAtIndex:0];
 
-    NSString* str = [options valueForKey:OPT_WWW_ROOT];
+    NSString* str = [options valueForKey:OPT_WWW_DIR_NAME];
+    if(str) self.www_dir_name = str;
+
+    str = [options valueForKey:OPT_WWW_ROOT];
     if(str) self.www_root = str;
 
     str = [options valueForKey:OPT_PORT];
@@ -156,11 +161,12 @@
     if(self.localhost_only) [self.httpServer setInterface:IP_LOCALHOST];
 
     // Serve files from our embedded Web folder
+    const char * root = [self.www_dir_name UTF8String];
     const char * docroot = [self.www_root UTF8String];
-    if(*docroot == '/') {
+    if(*docroot == '/' || *root == '/') {
         self.localPath = self.www_root;
     } else {
-        NSString* basePath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"www"];
+        NSString* basePath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:self.www_dir_name];
         self.localPath = [NSString stringWithFormat:@"%@/%@", basePath, self.www_root];
     }
     NSLog(@"Setting document root: %@", self.localPath);

--- a/www/CorHttpd.js
+++ b/www/CorHttpd.js
@@ -29,6 +29,10 @@ corhttpd_exports.getURL = function(success, error) {
 	  exec(success, error, "CorHttpd", "getURL", []);
 };
 
+// Compatibility for @ionic-native/httpd plugin. Keep this until the following issue is resolved:
+// https://github.com/danielsogl/awesome-cordova-plugins/issues/3805
+corhttpd_exports.getUrl =  corhttpd_exports.getURL
+
 corhttpd_exports.getLocalPath = function(success, error) {
 	  exec(success, error, "CorHttpd", "getLocalPath", []);
 };

--- a/www/CorHttpd.js
+++ b/www/CorHttpd.js
@@ -5,36 +5,38 @@ var argscheck = require('cordova/argscheck'),
 var corhttpd_exports = {};
 
 corhttpd_exports.startServer = function(options, success, error) {
-	  var defaults = {
-			    'www_root': '',
-			    'port': 8888,
-			    'localhost_only': false
-			  };
-	  
-	  // Merge optional settings into defaults.
-	  for (var key in defaults) {
-	    if (typeof options[key] !== 'undefined') {
-	      defaults[key] = options[key];
-	    }
-	  }
-			  
-  exec(success, error, "CorHttpd", "startServer", [ defaults ]);
+    var defaults = {
+        // For Cordova this is `www`. For Capacitor it's `public`.
+        'www_dir_name': 'www',  
+        'www_root': '',
+        'port': 8888,
+        'localhost_only': false
+    };
+
+    // Merge optional settings into defaults.
+    for (var key in defaults) {
+        if (typeof options[key] !== 'undefined') {
+            defaults[key] = options[key];
+        }
+    }
+
+    exec(success, error, "CorHttpd", "startServer", [defaults]);
 };
 
 corhttpd_exports.stopServer = function(success, error) {
-	  exec(success, error, "CorHttpd", "stopServer", []);
+    exec(success, error, "CorHttpd", "stopServer", []);
 };
 
 corhttpd_exports.getURL = function(success, error) {
-	  exec(success, error, "CorHttpd", "getURL", []);
+    exec(success, error, "CorHttpd", "getURL", []);
 };
 
 // Compatibility for @ionic-native/httpd plugin. Keep this until the following issue is resolved:
 // https://github.com/danielsogl/awesome-cordova-plugins/issues/3805
-corhttpd_exports.getUrl =  corhttpd_exports.getURL
+corhttpd_exports.getUrl = corhttpd_exports.getURL
 
 corhttpd_exports.getLocalPath = function(success, error) {
-	  exec(success, error, "CorHttpd", "getLocalPath", []);
+    exec(success, error, "CorHttpd", "getLocalPath", []);
 };
 
 module.exports = corhttpd_exports;


### PR DESCRIPTION
This adds compatibility for the `@ionic-native/httpd` plugin wrapper and capacitor builds. This PR is to resolve https://github.com/floatinghotpot/cordova-httpd/issues/78 and https://github.com/floatinghotpot/cordova-httpd/issues/77.

Also relates to https://github.com/danielsogl/awesome-cordova-plugins/issues/3805.